### PR TITLE
Trikebike

### DIFF
--- a/data/json/items/vehicle/wheel.json
+++ b/data/json/items/vehicle/wheel.json
@@ -205,6 +205,24 @@
     "width": 3
   },
   {
+    "id": "wheel_tricycle",
+    "category": "veh_parts",
+    "type": "WHEEL",
+    "name": "set of tricycle wheels",
+    "name_plural": "sets of tricycle wheels",
+    "description": "A set of hard plastic wheels with one larger than the other two.  Proudly made in the USA by Double Dango Productions.",
+    "weight": 750,
+    "volume": 3,
+    "price": 7000,
+    "bashing": 3,
+    "to_hit": -2,
+    "material": [ "plastic" ],
+    "symbol": "]",
+    "color": "dark_gray",
+    "diameter": 7,
+    "width": 1
+  },
+  {
     "id": "wheel_wheelchair",
     "type": "WHEEL",
     "category": "veh_parts",

--- a/data/json/mapgen/bike_shop.json
+++ b/data/json/mapgen/bike_shop.json
@@ -114,7 +114,8 @@
       [ "unicycle", 50 ],
       [ "scooter", 100 ],
       [ "scooter_electric", 50 ],
-      [ "tandem", 300 ]
+      [ "tandem", 300 ],
+      [ "tricycle", 50 ]
     ]
   },
   {

--- a/data/json/mapgen/daycare.json
+++ b/data/json/mapgen/daycare.json
@@ -103,6 +103,10 @@
         { "monster": "GROUP_MAYBE_ZOMBIE", "x": [ 13, 20 ], "y": 19 },
         { "monster": "GROUP_SCHOOL", "x": [ 3, 7 ], "y": [ 12, 16 ] },
         { "monster": "GROUP_SCHOOL", "x": [ 3, 10 ], "y": [ 4, 8 ] }
+      ],
+      "place_vehicles": [
+        { "vehicle": "tricycle", "x": 12, "y": 17, "chance": 5, "status": 0 },
+        { "vehicle": "tricycle", "x": 2, "y": 10, "chance": 15, "status": 0 }
       ]
     }
   }

--- a/data/json/mapgen/house/house_quiverfull.json
+++ b/data/json/mapgen/house/house_quiverfull.json
@@ -124,6 +124,10 @@
       "place_monsters": [
         { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 },
         { "monster": "GROUP_QUIVERFULL", "x": [ 2, 14 ], "y": [ 15, 21 ], "chance": 1 }
+      ],
+      "place_vehicles": [
+        { "vehicle": "tricycle", "x": 10, "y": 8, "chance": 1, "status": 0 },
+        { "vehicle": "tricycle", "x": 4, "y": 21, "chance": 5, "status": 0 }
       ]
     }
   }

--- a/data/json/mapgen/mall.json
+++ b/data/json/mapgen/mall.json
@@ -2795,7 +2795,10 @@
         { "item": "beauty", "x": [ 16, 16 ], "y": [ 0, 1 ], "chance": 60 },
         { "item": "cleaning", "x": [ 18, 18 ], "y": [ 1, 1 ], "chance": 60 }
       ],
-      "place_monsters": [ { "monster": "GROUP_MALL", "x": [ 2, 23 ], "y": [ 1, 22 ], "density": 0.05 } ]
+      "place_monsters": [ { "monster": "GROUP_MALL", "x": [ 2, 23 ], "y": [ 1, 22 ], "density": 0.05 } ],
+      "place_vehicles": [
+        { "vehicle": "tricycle", "x": 20, "y": 23, "chance": 25, "status": 0 }
+      ]
     }
   },
   {
@@ -3280,6 +3283,13 @@
         { "item": "toy_store", "x": [ 6, 7 ], "y": [ 0, 3 ], "chance": 60 },
         { "item": "toy_store", "x": [ 2, 3 ], "y": [ 0, 3 ], "chance": 60 }
       ],
+      ],
+      "place_vehicles": [
+        { "vehicle": "tricycle", "x": 2, "y": 4, "chance": 20, "status": 0 },
+        { "vehicle": "tricycle", "x": 3, "y": 4, "chance": 20, "status": 0 },
+        { "vehicle": "tricycle", "x": 6, "y": 4, "chance": 20, "status": 0 },
+        { "vehicle": "tricycle", "x": 7, "y": 4, "chance": 20, "status": 0 }
+      ]
       "place_monsters": [ { "monster": "GROUP_MALL", "x": [ 2, 23 ], "y": [ 1, 22 ], "density": 0.3 } ]
     }
   },

--- a/data/json/mapgen/mall.json
+++ b/data/json/mapgen/mall.json
@@ -3283,14 +3283,13 @@
         { "item": "toy_store", "x": [ 6, 7 ], "y": [ 0, 3 ], "chance": 60 },
         { "item": "toy_store", "x": [ 2, 3 ], "y": [ 0, 3 ], "chance": 60 }
       ],
-      ],
+      "place_monsters": [ { "monster": "GROUP_MALL", "x": [ 2, 23 ], "y": [ 1, 22 ], "density": 0.3 } ],
       "place_vehicles": [
         { "vehicle": "tricycle", "x": 2, "y": 4, "chance": 20, "status": 0 },
         { "vehicle": "tricycle", "x": 3, "y": 4, "chance": 20, "status": 0 },
         { "vehicle": "tricycle", "x": 6, "y": 4, "chance": 20, "status": 0 },
         { "vehicle": "tricycle", "x": 7, "y": 4, "chance": 20, "status": 0 }
       ]
-      "place_monsters": [ { "monster": "GROUP_MALL", "x": [ 2, 23 ], "y": [ 1, 22 ], "density": 0.3 } ]
     }
   },
   {

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -144,7 +144,8 @@
       [ "pickup", 300 ],
       [ "portable_generator", 50 ],
       [ "bicycle", 150 ],
-      [ "bicycle_dirt", 125 ]
+      [ "bicycle_dirt", 125 ],
+      [ "tricycle", 5 ]
     ]
   },
   {

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -283,6 +283,30 @@
     "extend": { "flags": [ "STEERABLE" ] }
   },
   {
+    "id": "wheel_tricycle",
+    "type": "vehicle_part",
+    "name": "tricycle wheels",
+    "item": "wheel_tricycle",
+    "location": "under",
+    "symbol": "|",
+    "broken_symbol": "x",
+    "color": "dark_gray",
+    "difficulty": 0,
+    "durability": 30,
+    "description": "A set of three plastic wheels, with a larger one in the front, mounted with bolts.",
+    "damage_modifier": 50,
+    "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 3 ] } ],
+    "requirements": {
+      "install": { "time": 30000, "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "removal": { "time": 15000, "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": 5000, "using": [ [ "adhesive", 1 ] ] }
+    },
+    "rolling_resistance": 10,
+    "wheel_type": "standard",
+    "contact_area": 10,
+    "flags": [ "STABLE", "STEERABLE", "TOOL_WRENCH", "WHEEL" ]
+  },
+  {
     "id": "wheel_unicycle",
     "type": "vehicle_part",
     "name": "unicycle wheel",

--- a/data/json/vehicles/bikes.json
+++ b/data/json/vehicles/bikes.json
@@ -176,6 +176,15 @@
     ]
   },
   {
+    "id": "tricycle",
+    "type": "vehicle",
+    "name": "Children's Tricycle",
+    "blueprint": [ "#" ],
+    "parts": [
+      { "x": 0, "y": 0, "parts": [ "xlframe_vertical", "saddle", "foot_pedals", "wheel_tricycle" ] }
+    ]
+  },
+  {
     "id": "unicycle",
     "type": "vehicle",
     "name": "Unicycle",


### PR DESCRIPTION
<!--
### How to use
Leave the headings unless they don't apply to your PR, replace commented out text (surrounded with <!–– and ––>) with text describing your PR.
-->

#### Summary
<!--
A one-line description of your change that will be extracted and added to the [project changelog](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt).

The format is (ignore the square brackets): ```SUMMARY: [Category] "[description]"```

The categories to choose from are:

* Features
* Content
* Interface
* Mods
* Balance
* Bugfixes
* Performance
* Infrastructure
* Build
* I18N

Example: ```SUMMARY: Content "Adds new mutation category 'Mouse'"```

See the [Changelog Guidelines](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md) for explanations of the categories.
-->
```SUMMARY: Content "Adds a children's tricycle with appropriate wheels and spawn locations."```
#### Purpose of change
<!--
If there's an existing issue describing the problem this PR addresses or the feature it adds, please link it like: ```#1234```
If it *fully* resolves an issue, link it like: ```Fixes #1234```
Even if the issue describes the problem, please provide a few-sentence summary here.
Example: ```Fixes #1234 - XL mutants cannot wear arm/leg splints due to missing OVERSIZE flag.```
If there is no related issue, please describe the issue you are addressing, including how to trigger a bug if this is a bugfix.
Don't put the backticks around the `#` and issue or pull request number to allow the GitHub automatically reference to it.
-->
Lack of toys and "child" vehicles, so decided to add one.
#### Describe the solution
<!--
How does the feature work, or how does this fix a bug?
The easier you make your solution to understand, the faster it can get merged.
-->
Adds a tricycle that falls between unicycle and caster. Handles extremely poorly offroad but doesn't ruin grass tiles yet like I remember or tell my kids.
#### Describe alternatives you've considered
<!--
A clear and concise description of any alternative solutions or features you've considered.
-->
Not adding it.
#### Additional context
<!--
Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.
-->
Added spawn locations to areas I felt would warrant them without digging too deep (probably a bit more common in houses, but for now it spawns in the big family house [one with american flag, bible and quiver and huge room for kids] and extremely rarely as an alternative for suburban homes (commonly in the driveway/garage --- figure the people escaped in their vehicle and left behind the kid stuff).